### PR TITLE
Add QOL functions: save/load translated history and selected target language.

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -23,7 +23,8 @@
       <div id="result"></div>
       <button id="copyButton" style="display: none;">Copy</button>
     </div>
-
+    <div id="translatedContainer"></div>
+    <button id="clearTranslationsButton">Clear</button>
     <script src="api.js"></script>
     <script src="popup.js"></script>
   </body>

--- a/popup.js
+++ b/popup.js
@@ -51,6 +51,25 @@ for (const key in supported_languages) {
   targetLanguageSelect.appendChild(option);
 }  
 
+async function saveSelectedLanguage(lang) {
+ return new Promise((resolve) => {
+   chrome.storage.local.set({ selectedLanguage: lang }, () => {
+     resolve();
+   });
+ });
+}
+
+async function getSelectedLanguage() {
+ return new Promise((resolve) => {
+   chrome.storage.local.get("selectedLanguage", (data) => {
+     resolve(data.selectedLanguage || "English");
+   });
+ });
+}
+
+targetLanguage.addEventListener("change", async (event) => {
+  await saveSelectedLanguage(event.target.value);
+});
 
 function showApiKeyForm() {
   document.getElementById("api-key-container").style.display = "block";
@@ -178,6 +197,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   } else {
     showApiKeyForm();
   }
+
+  //Load and set the selected language
+  const selectedLang = await getSelectedLanguage();
+  targetLanguage.value = selectedLang;
 
   // Load and display translated contents
   const translations = await getTranslations();


### PR DESCRIPTION
Some QoL changes I'm currently testing:
・Being able to save the selected target language. Not a huge time saver for user but less boring operations when my language is not on the top of the list. (Default is English)
・Being able to autosave/load translated contents in the same panel. The layout is not good but showing them is helpful
・Clear button to delete all history.

Also please add Vietnamese to the language list, very appreciate  (>᎑<`๑)